### PR TITLE
OpenSSL::Digest::Digest is deprecated, use OpenSSL::Digest instead

### DIFF
--- a/lib/aliyun/oss/authentication.rb
+++ b/lib/aliyun/oss/authentication.rb
@@ -69,7 +69,7 @@ module Aliyun
           memoized :canonical_string
     
           def encoded_canonical
-            digest   = OpenSSL::Digest::Digest.new('sha1')
+            digest   = OpenSSL::Digest.new('sha1')
             b64_hmac = [OpenSSL::HMAC.digest(digest, secret_access_key, canonical_string)].pack("m").strip
             url_encode? ? CGI.escape(b64_hmac) : b64_hmac
           end


### PR DESCRIPTION
- see https://github.com/ruby/ruby/pull/446
